### PR TITLE
dev, cancel ignore dyn so.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.pch
 
 # Compiled Dynamic libraries
-*.so
+#*.so
 *.dylib
 *.dll
 


### PR DESCRIPTION
ignore should not include so. due to py called so.